### PR TITLE
added simple snack subscription request handling

### DIFF
--- a/Snackify/Model Controllers/SnackManager.swift
+++ b/Snackify/Model Controllers/SnackManager.swift
@@ -18,6 +18,7 @@ class SnackManager {
     
     var allSnacksOptions: [Snack]?
     var currentOrderSnacks: [Snack] = []
+    var snackRequests: [Snack] = []
     var subsOrderDeadline: String = "11/23/2019"
     
     // MARK: - Init
@@ -87,5 +88,9 @@ class SnackManager {
     
     func addSnackToCurrentSubscription(_ snack: Snack) {
         currentOrderSnacks.append(snack)
+    }
+    
+    func requestSnackForSubscription(_ snack: Snack) {
+        snackRequests.append(snack)
     }
 }

--- a/Snackify/View Controllers/LoginViewController.swift
+++ b/Snackify/View Controllers/LoginViewController.swift
@@ -174,9 +174,12 @@ class LoginViewController: UIViewController {
             do {
                 let _ = try result.get()
                 DispatchQueue.main.async {
-                    self.delegate?.snackManager = SnackManager(networkManager: self.networkManager!)
+                    if self.delegate?.snackManager == nil {
+                        self.delegate?.snackManager = SnackManager(networkManager: self.networkManager!)
+                    }
                     self.delegate?.updateViews()
                     self.dismiss(animated: true, completion: nil)
+                    self.delegate?.showRequestAlertIfAdmin()
                 }
             } catch {
                 NSLog("Error loginng in: \(error)")

--- a/Snackify/View Controllers/SnackDetailViewController.swift
+++ b/Snackify/View Controllers/SnackDetailViewController.swift
@@ -97,6 +97,8 @@ class SnackDetailViewController: UIViewController {
         alert.addAction(UIAlertAction(title: confirmActionText, style: .default) { (alertAction) in
             if let isAdmin = self.snackManager?.networkManager.userType?.isAdmin, isAdmin {
                 self.snackManager?.addSnackToCurrentSubscription(self.snack!)
+            } else {
+                self.snackManager?.requestSnackForSubscription(self.snack!)
             }
             self.dismiss(animated: true, completion: nil)
         })

--- a/Snackify/View Controllers/SnacksMainViewController.swift
+++ b/Snackify/View Controllers/SnacksMainViewController.swift
@@ -51,8 +51,34 @@ class SnacksMainViewController: UIViewController {
     
     @IBAction func logOutButtonTapped(_ sender: UIBarButtonItem) {
         networkManager.logOut()
-        snackManager = nil
+//        snackManager = nil
         performSegue(withIdentifier: "LoginModalSegue", sender: self)
+    }
+    
+    func showRequestAlertIfAdmin() {
+        guard let isAdmin = networkManager.userType?.isAdmin,
+            isAdmin,
+            let noSnackRequests = snackManager?.snackRequests.isEmpty,
+            !noSnackRequests
+            else { return }
+//        guard (networkManager.userType?.isAdmin ?? false) && !(snackManager?.snackRequests.isEmpty ?? true) else { return }
+        let requestAlert: UIAlertController = {
+            let alert = UIAlertController(
+                title: "New subscription requests!",
+                message: "Your employees have requested new subscription items. Add them to your subscription order?\n(You'll have time to review these before checkout.)",
+                preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "Clear requests", style: .cancel) { (alertAction) in
+                self.snackManager?.snackRequests = []
+            })
+            alert.addAction(UIAlertAction(title: "Add items to order", style: .default) { (alertAction) in
+                guard let snackRequests = self.snackManager?.snackRequests else { return }
+                for snack in snackRequests {
+                    self.snackManager?.addSnackToCurrentSubscription(snack)
+                }
+            })
+            return alert
+        }()
+        self.present(requestAlert, animated: true, completion: nil)
     }
     
     // MARK: - Navigation


### PR DESCRIPTION
When an employee requests a subscription, that snack is added to an array. When an admin signs in, they are alerted that they have no requests and can either abandon them or add them to the order.